### PR TITLE
Fix Extract hanging on progress dialog when config dir is missing

### DIFF
--- a/src/modules/FrontEnd/ProgressBar.py
+++ b/src/modules/FrontEnd/ProgressBar.py
@@ -32,8 +32,15 @@ class ProgressBar:
         label.pack(pady=10)
         cls.progress_bar = ttk.Progressbar(cls.progress_window, mode="determinate", maximum=total_iterations)
         cls.progress_bar.pack(pady=20)
-        task_thread = threading.Thread(target=tasks)
-        task_thread.start() 
+        def _safe_tasks():
+            try:
+                tasks()
+            except Exception as e:
+                log.error(f"Task thread crashed: {e!r}")
+                cls.progress_window.after(0, cls.Destroy)
+
+        task_thread = threading.Thread(target=_safe_tasks)
+        task_thread.start()
 
     @classmethod
     def Destroy(cls):

--- a/src/modules/GameManager/FileManager.py
+++ b/src/modules/GameManager/FileManager.py
@@ -545,6 +545,8 @@ class FileManager:
                     else:
                         configFile = ini_file_path ## compatibility for old patches
 
+                    os.makedirs(os.path.dirname(configFile), exist_ok=True)
+
                     if os.path.exists(configFile):
                         config.read(configFile, encoding="utf-8")
 


### PR DESCRIPTION
## Summary
Extract stuck on MacOS

- The Extract flow builds an .ini path at `<ini_file_path>/<configName>.ini` but only the *parent* of `ini_file_path` was being created. On a fresh extract that target dir doesn't exist yet, so `open(configFile, "w+")` raises `FileNotFoundError`.
- The exception kills the worker thread before `ProgressBar.End()` runs, leaving the "Downloading / NX-Optimizer Patching..." window visible forever and the UI unresponsive (reproduced on macOS arm64).

## Changes
- `src/modules/GameManager/FileManager.py` — `os.makedirs(os.path.dirname(configFile), exist_ok=True)` now runs after `configFile` is computed, so the actual containing directory is created (not just its parent). Works for both the legacy "Keys" path (where `configFile == ini_file_path`) and the new per-config layout.
- `src/modules/FrontEnd/ProgressBar.py` — wrap the task callable in a try/except. If the worker crashes, schedule `Destroy` on the Tk thread via `after(0, …)` so the progress window closes instead of stranding the UI. Errors are still logged.

## Test plan
- [x] Extract on macOS (Apple Silicon) with TOTK selected — completes, "Extracted Files/!!!!TOTK Optimizer/UltraCam/TOTK/Config/UI.ini" is written, progress window closes.
- [x] Forced an exception inside `run_tasks` — progress window now closes; previously it hung.
- [ ] Extract on Windows / Linux to confirm no regression for the "Keys" legacy path.